### PR TITLE
Bugfix: sets hierarkey-type for earliest due date

### DIFF
--- a/pretix_sepadebit/signals.py
+++ b/pretix_sepadebit/signals.py
@@ -222,3 +222,4 @@ settings_hierarkey.add_default(
 )
 
 
+settings_hierarkey.add_default("payment_sepadebit_earliest_due_date", None, date)


### PR DESCRIPTION
Without this type hierarkey returned the stored value as a string. 
This works ok with the datewidget if your locale is english, but will be discarded if it isn't. Showing an empty date-input to the user, even if a value is set.

