### PR TITLE
Change BIC check to lookup

### DIFF
--- a/pretix_sepadebit/templates/pretix_sepadebit/checkout_payment_confirm.html
+++ b/pretix_sepadebit/templates/pretix_sepadebit/checkout_payment_confirm.html
@@ -4,7 +4,8 @@
 <div class="form-horizontal">
     <p>
         {% blocktrans trimmed with iban=iban date=date|date:"SHORT_DATE_FORMAT" %}
-            We will debit the total amount displayed above from your bank account <strong>{{ iban }}</strong>.
+            We will debit the total amount displayed above from your bank account <strong>{{ iban }}</strong>
+            (<strong>BIC: {{ bic }}</strong>).
             You hereby agree that the amount will be withdrawn from your bank account <strong>on or shortly after
             {{ date }}</strong>.
         {% endblocktrans %}


### PR DESCRIPTION
Removing the payment BIC FormField and looking up the BIC corresponding to the IBAN instead, since it is no longer mandatory to provide the BIC

(german source: https://www.verbraucherzentrale.de/wissen/geld-versicherungen/sparen-und-anlegen/sepa-europaweite-regeln-im-zahlungsverkehr-11512)

I would have preferred to leave the field and make it optional, but there seems to be no indicator on those FormFields, even when setting `required=False`, but that's why for now the FormField declaration has only been commented out